### PR TITLE
fix (edit-village): change regex pattern for latlong input format

### DIFF
--- a/components/Village/Add/index.vue
+++ b/components/Village/Add/index.vue
@@ -278,7 +278,7 @@ export default {
       }
     },
     'form.longitude' () {
-      const regexPoint = /^(-?\d+(\.\d+)?)$/
+      const regexPoint = /^-?(\d+)(\.\d+)$/
       if (regexPoint.test(this.form.longitude) || !this.form.longitude.length) {
         this.errors.longitude = null
       } else {
@@ -286,7 +286,7 @@ export default {
       }
     },
     'form.latitude' () {
-      const regexPoint = /^(-?\d+(\.\d+)?)$/
+      const regexPoint = /^-?(\d+)(\.\d+)$/
       if (regexPoint.test(this.form.latitude) || !this.form.latitude.length) {
         this.errors.latitude = null
       } else {

--- a/components/Village/Edit/index.vue
+++ b/components/Village/Edit/index.vue
@@ -287,7 +287,7 @@ export default {
       }
     },
     'form.longitude' () {
-      const regexPoint = /^(-?\d+(\.\d+)?)$/
+      const regexPoint = /^-?(\d+)(\.\d+)$/
       if (regexPoint.test(this.form.longitude) || !this.form.longitude.length) {
         this.errors.longitude = null
       } else {
@@ -295,7 +295,7 @@ export default {
       }
     },
     'form.latitude' () {
-      const regexPoint = /^(-?\d+(\.\d+)?)$/
+      const regexPoint = /^-?(\d+)(\.\d+)$/
       if (regexPoint.test(this.form.latitude) || !this.form.latitude.length) {
         this.errors.latitude = null
       } else {


### PR DESCRIPTION
## Changes

- Change regex pattern for latlong input format in edit and add form village
- The regex  pattern is `XX.XXXX` or `-XX.XXXX`
- The value should be in decimal format

## Preview

1.  Change regex pattern for latlong input format

https://user-images.githubusercontent.com/79241754/186306124-81f861ec-ffcc-4ece-8e12-8e686ba2e672.mp4

## Evidence
title: fix (edit-village): change regex pattern for latlong input format
project: Desa Digital
participants: @doohanas @yoslie @naufalihsank @Ibwedagama @agunghide 