### PR TITLE
fix (add-partner): enable tambahkan button after error in company field

### DIFF
--- a/components/Mitra/Add/index.vue
+++ b/components/Mitra/Add/index.vue
@@ -180,6 +180,11 @@ export default {
       } else {
         this.errors.email = 'Isian email tidak valid.'
       }
+    },
+    'form.company' (newCompany, oldCompany) {
+      if (newCompany && newCompany !== oldCompany) {
+        this.errors.company = null
+      }
     }
   },
   methods: {


### PR DESCRIPTION
## Changes

- Add validation in the company field
- Enable tambahkan button after user try fill the company field

## Preview

1. Before

https://user-images.githubusercontent.com/79241754/187864232-15022246-4702-4416-9c4e-d5b439302ccc.mp4

2. After

https://user-images.githubusercontent.com/79241754/187864287-17e96fad-9fec-49e3-90ff-e74ff110e898.mp4

## Evidence
title: fix (add-partner): enable tambahkan button after error in company field
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @naufalihsank 
