### PR TITLE
feat: to activate the perangkat desa user in the table list

### DIFF
--- a/components/PerangkatDesa/index.vue
+++ b/components/PerangkatDesa/index.vue
@@ -45,6 +45,7 @@
             :status="item.status"
             @delete="deleteData(item)"
             @verify="verifyUser(item)"
+            @activate="activateUser(item)"
             @deactivate="deactivateUser(item)"
           />
         </template>
@@ -389,6 +390,47 @@ export default {
         this.$store.dispatch('dialog/showDialog', {
           header: 'Penonaktifan Perangkat Desa Gagal',
           title: 'Penonaktifan Perangkat Desa gagal dilakukan.',
+          message: this.contentPerangkatDesa.data,
+          iconMessage: 'warning',
+          iconColor: 'text-red-700',
+          btnLeftLabel: 'Keluar',
+          btnLeftVariant: 'primary',
+          dialogType: 'information',
+          actionBtnLeft: () => this.$fetch()
+        })
+      }
+    },
+    activateUser (item) {
+      this.dataPerangkatDesa = item
+      const { name, village } = item
+      this.contentPerangkatDesa.data = village?.name ? `${name} - ${village.name}` : name
+      this.$store.dispatch('dialog/showDialog', {
+        header: 'Aktifkan Perangkat Desa',
+        title: 'Apakah anda yakin ingin mengaktifkan perangkat desa ini?',
+        message: this.contentPerangkatDesa.data,
+        btnRightLabel: 'Ya, aktifkan perangkat desa ini',
+        actionBtnRight: () => this.onActivateUser()
+      })
+    },
+    async onActivateUser () {
+      const { id } = this.dataPerangkatDesa
+      try {
+        await this.$axios.patch(`/users/${id}/status`, { is_active: true })
+        this.$store.dispatch('dialog/showDialog', {
+          header: 'Pengaktifan Perangkat Desa Berhasil',
+          title: 'Pengaktifan perangkat desa telah berhasil dilakukan.',
+          message: this.contentPerangkatDesa.data,
+          iconMessage: 'check-mark-circle',
+          iconColor: 'text-green-700',
+          btnLeftVariant: 'primary',
+          btnLeftLabel: 'Saya mengerti',
+          dialogType: 'information',
+          actionBtnLeft: () => this.$fetch()
+        })
+      } catch (error) {
+        this.$store.dispatch('dialog/showDialog', {
+          header: 'Pengaktifan Perangkat Desa Gagal',
+          title: 'Pengaktifan perangkat desa gagal dilakukan.',
           message: this.contentPerangkatDesa.data,
           iconMessage: 'warning',
           iconColor: 'text-red-700',


### PR DESCRIPTION
## Changes

- Add `activate` event in `perangkat desa` list to activate the perangkat-desa user

## Preview

https://user-images.githubusercontent.com/79241754/190540635-07601a6c-0530-411e-be60-ca04a34e7f9a.mp4

## Evidence
title: feat: to activate the perangkat desa user in the table list
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @agunghide 