### PR TITLE
refactor: typo, wording, and function in detail desa digital

### DIFF
--- a/components/DesaDigital/Detail/index.vue
+++ b/components/DesaDigital/Detail/index.vue
@@ -21,14 +21,12 @@
           <tr>
             <td class="desa-digital-detail__content--width">
               <strong>Nama Lengkap</strong>
-              <span>:</span>
             </td>
             <td>{{ applicantName }}</td>
           </tr>
           <tr>
             <td>
               <strong>No HP</strong>
-              <span>:</span>
             </td>
             <td>{{ applicantPhoneNumber }}</td>
           </tr>

--- a/components/DesaDigital/Detail/index.vue
+++ b/components/DesaDigital/Detail/index.vue
@@ -257,10 +257,9 @@ export default {
     }
   },
   methods: {
-    joinData (data, otherData) {
-      const newOtherData = otherData ?? ''
+    joinData (data) {
       if (Array.isArray(data)) {
-        return data.join(', ') + `, ${newOtherData}`
+        return data.join(', ')
       } else {
         return '-'
       }

--- a/components/DesaDigital/Detail/index.vue
+++ b/components/DesaDigital/Detail/index.vue
@@ -239,7 +239,7 @@ export default {
       return this.item.properties.business?.commodity?.data ?? '-'
     },
     potentials () {
-      return this.joinData(this.item.properties?.potential?.data, this.item.properties.potential.other_potential)
+      return this.combineData(this.item.properties?.potential?.data, this.item.properties.potential.other_potential)
     },
     growthPotentials () {
       return this.item.properties?.potential?.growth_potential || '-'
@@ -260,6 +260,13 @@ export default {
     joinData (data) {
       if (Array.isArray(data)) {
         return data.join(', ')
+      } else {
+        return '-'
+      }
+    },
+    combineData (data, otherData) {
+      if (Array.isArray(data) && typeof otherData === 'string') {
+        return data.join(', ').concat(', ', otherData)
       } else {
         return '-'
       }

--- a/components/DesaDigital/Detail/index.vue
+++ b/components/DesaDigital/Detail/index.vue
@@ -90,7 +90,7 @@
             <td>{{ cellularNetwork }}</td>
           </tr>
           <tr>
-            <td><strong>Jaringan Intener</strong></td>
+            <td><strong>Jaringan Internet</strong></td>
             <td>{{ internetNetwork }}</td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Changes

- Fixing typo in detail desa digital page
- Remove semicolon in the `indentitas pemohon` section
- Refactor `joinData` function: remove second parameter
- Create `combineData` function: to concatenate two data (Array and String) and return a string separate with comma

## Preview

- Before

![image](https://user-images.githubusercontent.com/79241754/192727168-0553055f-e113-43fb-ad2e-8cd2be4d8007.png)

- After

![image](https://user-images.githubusercontent.com/79241754/192727335-8b9a7b12-ab73-41a3-9e51-097d57ae0324.png)

## Evidence
title: refactor: typo, wording, and function in detail desa digital
project: Desa Digital
participants: @doohanas @yoslie @Ibwedagama @agunghide